### PR TITLE
Hs2019 improvements

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,2 @@
+export { parseRequest } from './parser';
+export { verifyHMAC } from './verify';

--- a/lib/parser.d.ts
+++ b/lib/parser.d.ts
@@ -1,0 +1,83 @@
+import type { IncomingMessage } from 'http';
+
+export type ParsedRequest = {
+  scheme: 'Signature';
+  params: {
+    keyId: string;
+    algorithm: 'hs2019';
+    headers: string[];
+    signature: string;
+  };
+  signingString: string;
+};
+
+type ParseRequestOptions = {
+  /**
+   * allowed clock skew in seconds
+   * @default 300
+   */
+  clockSkew?: number;
+  /**
+   * required header names
+   * @default date or x-date
+   */
+  headers?: string[];
+  /**
+   * algorithms to support
+   * @default all
+   */
+  algorithms?: string;
+  /**
+   * should enforce latest spec parsing
+   * @default false
+   */
+  strict?: boolean;
+};
+
+/**
+ * Parses the 'Authorization' header out of an http.ServerRequest object.
+ *
+ * Note that this API will fully validate the Authorization header, and throw
+ * on any error.  It will not however check the signature, or the keyId format
+ * as those are specific to your environment.  You can use the options object
+ * to pass in extra constraints.
+ *
+ * As a response object you can expect this:
+ *
+ *     {
+ *       "scheme": "Signature",
+ *       "params": {
+ *         "keyId": "foo",
+ *         "algorithm": "rsa-sha256",
+ *         "headers": [
+ *           "date" or "x-date",
+ *           "digest"
+ *         ],
+ *         "signature": "base64"
+ *       },
+ *       "signingString": "ready to be passed to crypto.verify()"
+ *     }
+ *
+ * @param {Object} request an http.ServerRequest.
+ * @param {Object} options an optional options object with:
+ *                   - clockSkew: allowed clock skew in seconds (default 300).
+ *                   - headers: required header names (def: date or x-date)
+ *                   - algorithms: algorithms to support (default: all).
+ *                   - strict: should enforce latest spec parsing
+ *                             (default: false).
+ * @return {Object} parsed out object (see above).
+ * @throws {TypeError} on invalid input.
+ * @throws {InvalidHeaderError} on an invalid Authorization header error.
+ * @throws {InvalidParamsError} if the params in the scheme are invalid.
+ * @throws {MissingHeaderError} if the params indicate a header not present,
+ *                              either in the request headers from the params,
+ *                              or not in the params from a required header
+ *                              in options.
+ * @throws {StrictParsingError} if old attributes are used in strict parsing
+ *                              mode.
+ * @throws {ExpiredRequestError} if the value of date or x-date exceeds skew.
+ */
+export function parseRequest(
+  req: IncomingMessage,
+  opts?: ParseRequestOptions,
+): ParsedRequest;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,8 +36,11 @@ function InvalidAlgorithmError(message) {
 util.inherits(InvalidAlgorithmError, HttpSignatureError);
 
 function validateAlgorithm(algorithm) {
-  var alg = algorithm.toLowerCase().split('-');
+  if (algorithm.toLowerCase() === 'hs2019') {
+    return ['hmac', 'sha512'];
+  }
 
+  var alg = algorithm.toLowerCase().split('-');
   if (alg.length !== 2) {
     throw (new InvalidAlgorithmError(alg[0].toUpperCase() + ' is not a ' +
       'valid algorithm'));
@@ -53,7 +56,7 @@ function validateAlgorithm(algorithm) {
       'supported hash algorithm'));
   }
 
-  return (alg);
+  return alg;
 }
 
 ///--- API

--- a/lib/verify.d.ts
+++ b/lib/verify.d.ts
@@ -1,0 +1,13 @@
+import type { ParsedRequest } from './verify';
+
+/**
+ * Verify HMAC against shared secret.  You are expected to pass in an object
+ * that was returned from `parse()`.
+ *
+ * @param {Object} parsedReq the object you got from `parse`.
+ * @param {String | Buffer} secret HMAC shared secret.
+ * @return {Boolean} true if valid, false otherwise.
+ * @throws {TypeError} if you pass in bad arguments.
+ * @throws {InvalidAlgorithmError}
+ */
+export function verifyHMAC(parsedReq: ParsedRequest, secret: string): boolean;

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -154,6 +154,29 @@ test('valid raw hmac', function(t) {
   });
 });
 
+test('verifies hs2019: hmac-sha512 variant properly', function(t) {
+  server.tester = function(req, res) {
+    var parsed = httpSignature.parseRequest(req);
+    t.ok(httpSignature.verifyHMAC(parsed, rawhmacKey));
+
+    res.writeHead(200);
+    res.write(JSON.stringify(parsed, null, 2));
+    res.end();
+  };
+
+  const shaVariant = 'sha512';
+  const algorithm = 'hs2019';
+  options.headers.Date = jsprim.rfc1123(new Date());
+  var hmac = crypto.createHmac(shaVariant, rawhmacKey);
+  hmac.update('date: ' + options.headers.Date);
+  options.headers.Authorization = `Signature keyId="foo",algorithm="${algorithm}",signature="${hmac.digest('base64')}"`;
+
+  http.get(options, function(res) {
+    t.equal(res.statusCode, 200);
+    t.end();
+  });
+})
+
 test('invalid rsa', function(t) {
   server.tester = function(req, res) {
     var parsed = httpSignature.parseRequest(req);


### PR DESCRIPTION
Added typing and returning `hmac-sha512` as the algorithm type for `hs2019`

based on https://github.com/surgeventures/plug_signature/blob/master/lib/plug_signature/crypto.ex#L57